### PR TITLE
Adding policy and credentials to access all the orderForms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow the app to access all the orderForms to properly run the simulation
+
 ## [3.1.1] - 2020-11-30
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -48,6 +48,9 @@
       "name": "graphql-query"
     },
     {
+      "name": "AcessaTodosCarrinhos"
+    },
+    {
       "name": "outbound-access",
       "attrs": {
         "host": "{{account}}.vtexcommercestable.com.br",

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -80,7 +80,12 @@ export class Search extends ExternalClient {
   }
 
   private getOrderForm = async (orderFormId: string) => {
-    return this.http.get(`/api/checkout/pub/orderForm/${orderFormId}`)
+    return this.http.get(`/api/checkout/pub/orderForm/${orderFormId}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        VtexIdclientAutCookie: `${this.context.authToken}`,
+      },
+    })
   }
 
   private simulate = async (refids: [Items], orderForm: any) => {


### PR DESCRIPTION
#### What does this PR do? \*
Fix a limitation on the quickorder to run simulations

#### How to test it? \*
[Run the query here](https://wender--b2bstore.myvtex.com/_v/private/vtex.quickorder@3.1.1/graphiql/v1?operationName=getSkuFromRefIds&query=query%20getSkuFromRefIds(%24refids%3A%20%5BString%5D%2C%20%24orderFormId%3A%20String)%20%7B%0A%20%20skuFromRefIds(refids%3A%20%24refids%2C%20orderFormId%3A%20%24orderFormId)%20%7B%0A%20%20%20%20items%20%7B%0A%20%20%20%20%20%20sku%0A%20%20%20%20%20%20refid%0A%20%20%20%20%20%20availability%0A%20%20%20%20%20%20sellers%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&variables=%7B%0A%20%20%22refids%22%3A%5B%221000%22%2C%221003%22%2C%221105%22%5D%2C%0A%20%20%22orderFormId%22%3A%225e0f3dd310e24119ac2f8311abf651dc%22%0A%7D)
#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
