### PR TITLE
Ignoring duplicated refid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore duplicated refId
+
 ## [3.1.2] - 2020-12-01
 
 ### Fixed

--- a/node/package.json
+++ b/node/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.37.0",
+    "@vtex/api": "6.39.1",
     "@vtex/test-tools": "^1.2.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^6.8.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1319,10 +1319,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@vtex/api@6.37.0":
-  version "6.37.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.0.tgz#a07e6adbfc02866f901cf0cfff2155f2c279adc5"
-  integrity sha512-Vy970ZfgOttrxeiJW2oM8rQ0E8t/HE5cQhbGIawfJsu35HEWA9NnWRSR3bdLMczT9oYIY9QwE8IfdU4b44dhKw==
+"@vtex/api@6.39.1":
+  version "6.39.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
+  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -6016,7 +6016,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -310,8 +310,17 @@ const ReviewBlock: StorefrontFunctionComponent<WrappedComponentProps & any> = ({
     }
   }
 
-  const getRefIds = async (refids: any, reviewed: any) => {
+  const getRefIds = async (_refids: any, reviewed: any) => {
     onRefidLoading(true)
+    let refids = {}
+
+    if (_refids.length) {
+      _refids.forEach(refid => {
+        refids[refid] = true
+      })
+      refids = Object.getOwnPropertyNames(refids)
+    }
+
     const query = {
       query: getRefIdTranslation,
       variables: { refids, orderFormId },


### PR DESCRIPTION
#### What does this PR do? \*
Fixes an issue that happens when you send a duplicated refid to the API 

#### How to test it? \*

Try uploading a spreadsheet with duplicates or pasting it to the textarea
1289000, 20
0130029, 2
0200659, 3
0207974,	5
0208079, 10
0208079, 10
2129502,	20
2174500,	2

[Workspace](https://wender--ecowaterb2b.myvtex.com/quickorder)
