### PR TITLE
Add items to cart in batches to prevent tax hub time outs

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.39.1",
+    "@vtex/api": "6.41.0",
     "@vtex/test-tools": "^1.2.0",
     "@vtex/tsconfig": "^0.2.0",
     "eslint": "^6.8.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1319,10 +1319,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@vtex/api@6.39.1":
-  version "6.39.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.39.1.tgz#ad675cf46404b0d21476ac441626843b6950c4a2"
-  integrity sha512-w3FghXguk4b+bOSOihB8I4+gGt7JljRCXFgirK9XiHDOr+uPsUEGhC4JeeQ42aBIEQeyGmQQOsyvZ+qZp2C/oA==
+"@vtex/api@6.41.0":
+  version "6.41.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.41.0.tgz#cee074ff49de8a5de92f3d353a4689275cb92f7b"
+  integrity sha512-RvfdpczsxCFacZkDSl2v2NmfD/bHFxHHn2xQsEwSQ+40snGxfOz56TlCbPbgMEtkC8Bf+1GGUkCIChRE6xnlLg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What does this PR do? \*

- Improve quick order functionality by splitting up cart items into batches
- There was an issue where you couldn't upload multiple XLS files back to back due to the tax hub timing out
- Original slack thread here: [https://vtex.slack.com/archives/CFJU5HYTV/p1616074996038100](url)

#### How to test it? \*

- You should be able to go through the checkout process multiple times using the upload function at [https://tonys--ecowaterb2b.myvtex.com/quickorder](url)
