### PR TITLE
[BugFix] Restricting the Quick Order Upload to accept only .xls and .xlsx files

### DIFF
--- a/react/UploadBlock.tsx
+++ b/react/UploadBlock.tsx
@@ -349,7 +349,7 @@ const UploadBlock: StorefrontFunctionComponent<UploadBlockInterface &
             <div
               className={`bg-base t-body c-on-base ph6 pb6 br3 b--muted-4 ${handles.dropzoneContainer}`}
             >
-              <Dropzone onDropAccepted={handleFile} onFileReset={handleReset}>
+              <Dropzone onDropAccepted={handleFile} onFileReset={handleReset} accept=".xls,xlsx">
                 <div className="pt7">
                   <div>
                     <span className={`f4 ${handles.dropzoneText}`}>


### PR DESCRIPTION
#### What does this PR do? \*

Restricts the Quick Order Upload to accept only .xls and .xslx files

#### How to test it? \*

Try to add a file that is not .xls or .xlsx in quick order upload

#### Describe alternatives you've considered, if any. \*

None

#### Related to / Depends on \*

None
