### PR TITLE
Fix SonarCloud to run PR's securely inside VTEX

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,37 +1,71 @@
-name: "[QE] SonarCloud"
+# D A N G E R - Read it, please!
+#
+# If the event is from pull_request_target, it must checked by a VTEX person,
+# if you think it's safe, you have to add label 'safe to test' to run SonarCloud.
+#
+# You MUST only give this label if there's NO CHANGES on WORKFLOWS.
+#
+# This is important to avoid been hacked.
+
+name: '[QE] SonarCloud'
 
 on:
+
+  # Trigger when the master is updated
   push:
     branches:
-      - master
-      - main
-      - release/*
-      - feature/*
-      - fix/*
-      - chore/*
-  pull_request:
-    types: [opened, synchronize, reopened]
-    
+    - master
+    - main
+    - chore/*
+    - feature/*
+    - fix/*
+   
+  # Trigger after label approval
+  pull_request_target:
+    branches:
+    - master
+    - main
+    types:
+    - labeled
+
 jobs:
+
+  # Job for SonarCloud analysis
+  # You must set the right SONAR_TOKEN token on your secrets
   sonarcloud:
+  
     name: SonarCloud
     runs-on: ubuntu-latest
+        
+    # Don't allow code changes from Workflows
+    permissions:
+      contents: read
+    
+    # Only run if it's PUSH or has 'safe to test' label
+    if: ${{ github.event_name == 'push' ||
+            ( 
+              github.event_name == 'pull_request_target' &&
+              contains(github.event.label.name, 'safe to test')
+            )
+         }}
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          
-      - name: Cache for node_modules
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Cache
         uses: actions/cache@v2
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-          
+
       - name: Install base packages
         run: yarn install --frozen-lockfile
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        
+
       - name: Install node packages
         run: yarn install --frozen-lockfile
         working-directory: ./node
@@ -44,6 +78,9 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
+        with:
+          # SonarCloud doesn't treat pull_request_target, so we need this
+          args: -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
#### What does this PR do?

Turn possible to run SonarCloud scan based on label. As this is a public repository, someone from VTEX need to inspect the code before authorize the analysis.