### PR TITLE
[Enhancement] Adding the message Unit Multiplier Of in autocomplete block as translatable

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,7 @@
   "store/quickorder.autocomplete.addButton": "Add",
   "store/quickorder.autocomplete.placeholder": "Search for a product...",
   "store/quickorder.autocomplete.selectSku": "Please select one SKU",
+  "store/quickorder.autocomplete.multiplierOf": "Unit Multiplier of",
   "store/quickorder.available": "Available",
   "store/quickorder.back": "Back",
   "store/quickorder.cannotBeDelivered": "Cannot be delivered",

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,6 +31,7 @@
   "store/quickorder.autocomplete.addButton": "Agregar",
   "store/quickorder.autocomplete.placeholder": "Buscar un producto...",
   "store/quickorder.autocomplete.selectSku": "Por favor, seleccione un SKU",
+  "store/quickorder.autocomplete.multiplierOf": "Multiplicador de unidades de",
   "store/quickorder.available": "Disponible",
   "store/quickorder.back": "Atrás",
   "store/quickorder.cannotBeDelivered": "No se puede entregar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -31,6 +31,7 @@
   "store/quickorder.autocomplete.addButton": "Adicionar",
   "store/quickorder.autocomplete.placeholder": "Busque um produto...",
   "store/quickorder.autocomplete.selectSku": "Por favor, selecione um SKU",
+  "store/quickorder.autocomplete.multiplierOf": "Multiplicador de Unidade de",
   "store/quickorder.available": "Disponível",
   "store/quickorder.back": "Voltar",
   "store/quickorder.cannotBeDelivered": "Não pode ser entregue",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -31,6 +31,7 @@
   "store/quickorder.autocomplete.addButton": "Adauga",
   "store/quickorder.autocomplete.placeholder": "Căutați un produs...",
   "store/quickorder.autocomplete.selectSku": "Selecteaza un SKU",
+  "store/quickorder.autocomplete.multiplierOf": "Multiplicator unitar al",
   "store/quickorder.available": "Disponibil",
   "store/quickorder.back": "Inapoi",
   "store/quickorder.cannotBeDelivered": "Nu poate fi livrat",

--- a/react/AutocompleteBlock.tsx
+++ b/react/AutocompleteBlock.tsx
@@ -396,7 +396,7 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
                     >
                       <span className="mr4">
                         <Tag type="warning" variation="low">
-                          Unit Multiplier of {unitMultiplier}
+                          <FormattedMessage id="store/quickorder.autocomplete.multiplierOf" />{' '}{unitMultiplier}
                         </Tag>
                       </span>
                     </div>


### PR DESCRIPTION
#### What does this PR do? \*

Makes the message "Unit Multiplier Of" in autocomplete block as an translatable message.

#### How to test it? \*

Use the quick order in different languages

#### Describe alternatives you've considered, if any. \*

None

#### Related to / Depends on \*

None
