### PR TITLE
[Bugfix] Upload block was not updating the order form automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where the upload block was not updating the order form automatically
+
 ## [3.7.0] - 2022-02-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed a bug where the upload block was not updating the order form automatically
+- Fixed a bug where the upload block was not updating the order form automatically.
 
 ## [3.7.0] - 2022-02-10
 

--- a/react/UploadBlock.tsx
+++ b/react/UploadBlock.tsx
@@ -270,14 +270,11 @@ const UploadBlock: FunctionComponent<UploadBlockInterface &
               }
             }),
           },
-        }).then((data: any) => {
-          data && setOrderForm(data.addToCart)
+        }).then((mutationRes: any) => {
+          mutationRes.data && setOrderForm(mutationRes.data.addToCart)
 
-          if (
-            data?.addToCart?.messages?.generalMessages &&
-            data.addToCart.messages.generalMessages.length
-          ) {
-            data.addToCart.messages.generalMessages.map((msg: any) => {
+          if (mutationRes?.data.addToCart?.messages?.generalMessages?.length) {
+            mutationRes.addToCart.messages.generalMessages.map((msg: any) => {
               return showToast({
                 message: msg.text,
                 action: undefined,


### PR DESCRIPTION
#### What does this PR do? \*
Fixes the bug where  the upload block was not updating the order form automatically

#### How to test it? \*
Add items with upload block and check if the Order Form from Order Manager is being automatically updated

#### Describe alternatives you've considered, if any. \*

None

#### Related to / Depends on \*

None