### PR TITLE
[Bugfix] Autocomplete block quantity button starting with 0 instead of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the issue that the autocomplete block quantity button was starting with 0 instead of 1
+
 ## [3.7.0] - 2022-02-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed the issue that the autocomplete block quantity button was starting with 0 instead of 1
+- Fixed the issue that the autocomplete block quantity button was starting with 0 instead of 1.
 
 ## [3.7.0] - 2022-02-10
 

--- a/react/AutocompleteBlock.tsx
+++ b/react/AutocompleteBlock.tsx
@@ -60,7 +60,7 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
   const { showToast } = useContext(ToastContext)
   const [state, setState] = useState<any>({
     selectedItem: null,
-    quantitySelected: 0,
+    quantitySelected: 1,
     unitMultiplier: 1,
   })
 


### PR DESCRIPTION
#### What does this PR do? \*
Sets the quantity input of autocomplete block to 1 by default, instead of 0

#### How to test it? \*
Open the autocomplete block and check the quantity input, the default value should be 1.

#### Describe alternatives you've considered, if any. \*

None

#### Related to / Depends on \*

None
