### PR TITLE
[Bugfix] Fixed a bug where removing all items from review block would send the user to a nothing to show page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where removing all items from review block would send the user to a "nothing to show" page.
+
 ## [3.7.0] - 2022-02-10
 
 ### Fixed

--- a/react/TextAreaBlock.tsx
+++ b/react/TextAreaBlock.tsx
@@ -17,7 +17,7 @@ import { usePWA } from 'vtex.store-resources/PWAContext'
 import { usePixel } from 'vtex.pixel-manager/PixelContext'
 
 import ReviewBlock from './components/ReviewBlock'
-import { ParseText, GetText } from './utils'
+import { ParseText } from './utils'
 
 const messages = defineMessages({
   success: {
@@ -182,7 +182,7 @@ const TextAreaBlock: FunctionComponent<TextAreaBlockInterface &
   }
 
   const onReviewItems = (items: any) => {
-    if (items) {
+    if (items?.length) {
       const show =
         items.filter((item: any) => {
           return !item.vtexSku
@@ -193,9 +193,8 @@ const TextAreaBlock: FunctionComponent<TextAreaBlockInterface &
         reviewItems: items,
         reviewState: true,
         showAddToCart: show,
-        textAreaValue: GetText(items),
       })
-    }
+    } else backList()
 
     return true
   }

--- a/react/UploadBlock.tsx
+++ b/react/UploadBlock.tsx
@@ -133,7 +133,7 @@ const UploadBlock: FunctionComponent<UploadBlockInterface &
   }
 
   const onReviewItems = (items: any) => {
-    if (items) {
+    if (items?.length) {
       const show =
         items.filter((item: any) => {
           return !item.vtexSku
@@ -146,7 +146,7 @@ const UploadBlock: FunctionComponent<UploadBlockInterface &
         showAddToCart: show,
         textAreaValue: GetText(items),
       })
-    }
+    } else backList()
 
     return true
   }


### PR DESCRIPTION
#### What does this PR do? \*
Fixes the bug where removing all items from review block would send the user to a "nothing to show" page.

#### How to test it? \*
Add item in the textAreaBlock and UploadBlock then remove each item, one by one, when removing the last item the user must go to the main page of the block, instead of to a page with the message "nothing to show"

#### Describe alternatives you've considered, if any. \*

None

#### Related to / Depends on \*

None
