### PR TITLE
[QUICKORDER-18] IS autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+
+- Replace the autocomplete search query with the intelligent search autocomplete
+
 ## [3.8.3] - 2022-04-01
 
 ### Fixed

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -1,4 +1,5 @@
-import { InstanceOptions, IOContext, JanusClient } from '@vtex/api'
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
 
 interface RefIdArgs {
   refids: any
@@ -58,7 +59,7 @@ export class Search extends JanusClient {
     if (res.status === 200) {
       const refs = Object.getOwnPropertyNames(res.data)
 
-      refs.forEach((id) => {
+      refs.forEach(id => {
         resultStr[id] = {
           sku: res.data[id],
           refid: id,
@@ -71,6 +72,7 @@ export class Search extends JanusClient {
         const promises = result.map(async (o: any) =>
           this.sellerBySku(o.sku, o.refid)
         )
+
         result = await Promise.all(promises)
       }
 
@@ -81,6 +83,7 @@ export class Search extends JanusClient {
         orderForm,
         refIdSellerMap
       )
+
       items.forEach((item: any) => {
         items[item.id] = item
       })
@@ -116,6 +119,7 @@ export class Search extends JanusClient {
       storePreferencesData: { countryCode },
       shippingData,
     } = orderForm
+
     const items = refids
       .filter((item: any) => {
         return !!item.sku
@@ -146,6 +150,7 @@ export class Search extends JanusClient {
         sellers: null,
       }
     }
+
     const url = `/api/catalog_system/pvt/sku/stockkeepingunitbyid/${skuId}`
     const res = await this.http.getRaw(url, {
       headers: {
@@ -153,6 +158,7 @@ export class Search extends JanusClient {
         Authorization: `bearer ${this.context.authToken}`,
       },
     })
+
     return res.data?.SkuSellers
       ? {
           sku: skuId,

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -1,12 +1,12 @@
-import {
+import type {
   IOContext,
-  MetricsAccumulator,
   ParamsContext,
   RecorderState,
   ServiceContext,
 } from '@vtex/api'
+import { MetricsAccumulator } from '@vtex/api'
 
-import { Clients } from './clients'
+import type { Clients } from './clients'
 
 if (!global.metrics) {
   console.error('No global.metrics at require time')
@@ -21,7 +21,6 @@ declare global {
     originalPath: string
     vtex: IOContext
   }
-
 
   interface Property {
     name: string

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,6 +1,7 @@
 import './globals'
 
-import { Cached, LRUCache, RecorderState, Service } from '@vtex/api'
+import type { Cached, RecorderState } from '@vtex/api'
+import { LRUCache, Service } from '@vtex/api'
 
 import { Clients } from './clients'
 import { resolvers } from './resolvers'

--- a/node/resolvers/search/autocomplete.ts
+++ b/node/resolvers/search/autocomplete.ts
@@ -15,6 +15,7 @@ import { path, split } from 'ramda'
  */
 const extractSlug = (item: SearchAutocompleteUnit) => {
   const href = split('/', item.href)
+
   return href[3]
 }
 

--- a/node/resolvers/search/autocomplete.ts
+++ b/node/resolvers/search/autocomplete.ts
@@ -16,7 +16,7 @@ import { path, split } from 'ramda'
 const extractSlug = (item: SearchAutocompleteUnit) => {
   const href = split('/', item.href)
 
-  return href[3]
+  return href.length > 3 ? href[3] : ''
 }
 
 export const resolvers = {

--- a/node/resolvers/search/autocomplete.ts
+++ b/node/resolvers/search/autocomplete.ts
@@ -15,7 +15,7 @@ import { path, split } from 'ramda'
  */
 const extractSlug = (item: SearchAutocompleteUnit) => {
   const href = split('/', item.href)
-  return item.criteria ? `${href[3]}/${href[4]}` : href[3]
+  return href[3]
 }
 
 export const resolvers = {

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -39,6 +39,7 @@ export const queries = {
     } = ctx
 
     const items = await search.sellers()
+
     return {
       cacheId: 'sellers',
       items,

--- a/node/resolvers/search/utils.ts
+++ b/node/resolvers/search/utils.ts
@@ -18,21 +18,28 @@ export const searchEncodeURI = (account: string) => (str: string) => {
       switch (c) {
         case '%':
           return '@perc@'
+
         case '"':
           return '@quo@'
+
         case "'":
           return '@squo@'
+
         case '.':
           return '@dot@'
+
         case '(':
           return '@lpar@'
+
         case ')':
           return '@rpar@'
+
         default: {
           return c
         }
       }
     })
   }
+
   return str
 }

--- a/node/typings/Autocomplete.ts
+++ b/node/typings/Autocomplete.ts
@@ -5,12 +5,11 @@ interface SearchAutocompleteItem {
     nameComplete: string
     imageUrl: string
   }
-  
+
 interface SearchAutocompleteUnit {
     items: SearchAutocompleteItem[]
     thumb: string
     thumbUrl: string | null
     name: string
     href: string
-    criteria: string
   }

--- a/react/components/QuickOrderAutocomplete.tsx
+++ b/react/components/QuickOrderAutocomplete.tsx
@@ -106,7 +106,9 @@ const QuickOrderAutocomplete: FunctionComponent<
       })
 
       setOptions(
-        !!data && !!data.productSuggestions && !!data.productSuggestions.products
+        !!data &&
+          !!data.productSuggestions &&
+          !!data.productSuggestions.products
           ? data.productSuggestions.products
           : []
       )
@@ -121,7 +123,7 @@ const QuickOrderAutocomplete: FunctionComponent<
     value: !term.length
       ? []
       : optionsResult
-        .filter((item: any) => {
+          .filter((item: any) => {
             return !!item.items[0].images[0].imageUrl
           })
           .map((item: any) => {

--- a/react/components/QuickOrderAutocomplete.tsx
+++ b/react/components/QuickOrderAutocomplete.tsx
@@ -19,9 +19,10 @@ const messages = defineMessages({
 })
 
 const getImageSrc = (img: string) => {
-  const src: any = img ? img.match(/src=["']([^"']+)/) : []
+  const td = img.split('/')
+  const ids = td[td.indexOf('ids') + 1]
 
-  return !!src && src.length ? src[1] : ''
+  return img.replace(ids, `${ids}-50-50`)
 }
 
 const CustomOption = (props: any) => {
@@ -105,8 +106,8 @@ const QuickOrderAutocomplete: FunctionComponent<
       })
 
       setOptions(
-        !!data && !!data.autocomplete && !!data.autocomplete.itemsReturned
-          ? data.autocomplete.itemsReturned
+        !!data && !!data.productSuggestions && !!data.productSuggestions.products
+          ? data.productSuggestions.products
           : []
       )
     }
@@ -120,15 +121,15 @@ const QuickOrderAutocomplete: FunctionComponent<
     value: !term.length
       ? []
       : optionsResult
-          .filter((item: any) => {
-            return !!item.thumb
+        .filter((item: any) => {
+            return !!item.items[0].images[0].imageUrl
           })
           .map((item: any) => {
             return {
-              value: item.productId,
-              label: item.name,
-              slug: item.slug,
-              thumb: getImageSrc(item.thumb),
+              value: item.items[0].itemId,
+              label: item.items[0].name,
+              slug: item.linkText,
+              thumb: getImageSrc(item.items[0].images[0].imageUrl),
             }
           }),
     lastSearched: {

--- a/react/queries/autocomplete.gql
+++ b/react/queries/autocomplete.gql
@@ -1,13 +1,16 @@
-query Autocomplete($maxRows: Int, $inputValue: String) {
-  autocomplete(maxRows: $maxRows, searchTerm: $inputValue)
+query Autocomplete($inputValue: String!) {
+  productSuggestions(fullText: $inputValue, hideUnavailableItems: true)
     @context(provider: "vtex.search-graphql") {
-    itemsReturned {
-      thumb
-      name
-      href
-      productId
-      criteria
-      slug
+      products {
+        items {
+          itemId
+          name
+          images {
+            imageUrl
+          }
+        }
+        link
+        linkText
+      }
     }
-  }
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 declare module 'vtex.styleguide' {
-  import { ComponentType } from 'react'
+  import type { ComponentType } from 'react'
 
   export const Input: ComponentType<InputProps>
 


### PR DESCRIPTION
What does this PR do? *

Replace the autocomplete search query with the intelligent search autocomplete

How to test it? *

Go to workspace [https://aurora--b2bstoreqa.myvtex.com/quickorder](https://github.com/vtex-apps/quickorder/compare/bugfix/url), and login to your account. Input keyword in the autocomplete block, you should now only see the assigned product collection