### PR TITLE
[QUICKORDER-16] Only show sellers who have the SKU in stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Filter sellers without stock from options in ReviewBlock component
+
+### Changed
+
+- Change `availability` and `unitMultiplier` to seller level information instead of item level
+
 ## [3.8.5] - 2022-05-23
 
 ### Fixed

--- a/graphql/types/Refids.graphql
+++ b/graphql/types/Refids.graphql
@@ -4,7 +4,12 @@ type Refids {
 type ItemsRefId {
   sku: String
   refid: String
+  sellers: [ItemsSeller]
+}
+
+type ItemsSeller {
+  id: String
+  name: String
   availability: String
   unitMultiplier: Float
-  sellers: [ItemsSeller]
 }

--- a/graphql/types/Sellers.graphql
+++ b/graphql/types/Sellers.graphql
@@ -1,7 +1,7 @@
 type SellersType {
-  items: [ItemsSeller]
+  items: [SellerInfo]
 }
-type ItemsSeller {
+type SellerInfo {
   id: String
   name: String
 }

--- a/react/queries/refids.gql
+++ b/react/queries/refids.gql
@@ -11,11 +11,11 @@ query getSkuFromRefIds(
     items {
       sku
       refid
-      availability
-      unitMultiplier
       sellers {
         id
         name
+        availability
+        unitMultiplier
       }
     }
   }


### PR DESCRIPTION
#### What does this PR do? \*

Filters out sellers who don't have the SKU in stock from the `Seller` column dropdown in `ReviewBlock` when using `TextAreaBlock` or `UploadBlock`. Prevents users from selecting a seller without the SKU in stock. SKUs that have no inventory in any seller will display a "Without stock" error status.

#### How to test it? \*

1. In the workspace [annaquickorder](https://annaquickorder--sandboxusdev.myvtex.com/quickorder)
2. Paste the following in _Copy/Paste Skus_ or  upload spreadsheet with same info in _Upload_
```
880030a,11
880010a,9
880020a,12
880021a,13
```
- 880030a - no stock in any seller
- 880010a - stock in seller 1 _and_ sandboxusdevseller
- 880020a - stock in seller 1 _only_
- 880021a - stock in seller sandboxusdevseller _only_

<img width="1439" alt="Screen Shot 2022-05-25 at 3 54 18 PM" src="https://user-images.githubusercontent.com/53097865/170357642-9560bfb3-71be-45f3-9ead-2f79c9443dad.png">

