### PR TITLE
[QUICKORDER-25] Fix minimum quantity selected in AutocompleteBlock to equal unit multiplier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix miniumn quantity selected in autocomplete block to equal unit multiplier
+
 ## [3.9.0] - 2022-05-25
 
 ### Added

--- a/react/AutocompleteBlock.tsx
+++ b/react/AutocompleteBlock.tsx
@@ -116,7 +116,7 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
     setState({
       ...state,
       selectedItem: null,
-      quantitySelected: 0,
+      quantitySelected: 1,
       unitMultiplier: 1,
     })
   }
@@ -225,6 +225,7 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
             ? { ...product[0], value: selectedSku, seller, data }
             : null,
         unitMultiplier: multiplier,
+        quantitySelected: multiplier,
       })
     }
 
@@ -254,6 +255,7 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
       ...state,
       selectedItem: newSelected,
       unitMultiplier: matchedItem.unitMultiplier,
+      quantitySelected: matchedItem.unitMultiplier,
     })
   }
 
@@ -408,7 +410,7 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
                       value={quantitySelected}
                       size="small"
                       type="number"
-                      min="1"
+                      min={unitMultiplier}
                       step={unitMultiplier}
                       onChange={(e: any) => {
                         if (e.target.value > 0) {


### PR DESCRIPTION
#### What does this PR do? \*
Sets the minimum quantity for a selected item in the AutocompleteBlock to the value of the unit multiplier. Starts incrementing at that minimum value instead of 1.

#### How to test it? \*
Test in workspace [annaquickorder](https://annaquickorder--sandboxusdev.myvtex.com/quickorder). 

1. Go to https://annaquickorder--sandboxusdev.myvtex.com/quickorder
2. In `One by One`, search for and select a product 

![quickorder25-demo](https://user-images.githubusercontent.com/53097865/174886550-988a7332-9a5f-4355-b961-c3fa19973ff9.gif)

