### PR TITLE
[QUICKORDER-26] Filter out sellers unavailable in orderForm's sales channel, Add error message when query for SKU info fails in ReviewBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed checkout simulation error by filtering out sellers unavailable in orderForm's sales channel
+
+### Added
+
+- Added error message when query for SKU info fails in ReviewBlock
+
 ## [3.9.2] - 2022-06-27
 
 ### Added

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -35,6 +35,7 @@
   "store/quickorder.available": "متاحة",
   "store/quickorder.back": "عودة",
   "store/quickorder.cannotBeDelivered": "لا يمكن تسليمه",
+  "store/quickorder.cannotGetSkuInfo": "تعذر الحصول على معلومات وحدة SKU",
   "store/quickorder.category.addButton": "إضافة عناصر إلى العربة",
   "store/quickorder.category.loading": "جاري التحميل...",
   "store/quickorder.category.noneSelection": "أدخل بعض الكمية على العناصر",

--- a/messages/context.json
+++ b/messages/context.json
@@ -35,6 +35,7 @@
   "store/quickorder.available": "store/quickorder.available",
   "store/quickorder.back": "store/quickorder.back",
   "store/quickorder.cannotBeDelivered": "store/quickorder.cannotBeDelivered",
+  "store/quickorder.cannotGetSkuInfo": "store/quickorder.cannotGetSkuInfo",
   "store/quickorder.category.addButton": "store/quickorder.category.addButton",
   "store/quickorder.category.loading": "store/quickorder.category.loading",
   "store/quickorder.category.noneSelection": "store/quickorder.category.noneSelection",

--- a/messages/en.json
+++ b/messages/en.json
@@ -35,6 +35,7 @@
   "store/quickorder.available": "Available",
   "store/quickorder.back": "Back",
   "store/quickorder.cannotBeDelivered": "Cannot be delivered",
+  "store/quickorder.cannotGetSkuInfo": "Could not get SKU information",
   "store/quickorder.category.addButton": "Add items to Cart",
   "store/quickorder.category.loading": "Loading...",
   "store/quickorder.category.noneSelection": "Enter some quantity on the items",

--- a/messages/es.json
+++ b/messages/es.json
@@ -35,6 +35,7 @@
   "store/quickorder.available": "Disponible",
   "store/quickorder.back": "Atrás",
   "store/quickorder.cannotBeDelivered": "No se puede entregar",
+  "store/quickorder.cannotGetSkuInfo": "No se pudo obtener la información de SKU",
   "store/quickorder.category.addButton": "Agregar ítems al carrito",
   "store/quickorder.category.loading": "Cargando...",
   "store/quickorder.category.noneSelection": "Ingresa una cantidad en los ítems",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -35,6 +35,7 @@
   "store/quickorder.available": "주문 가능",
   "store/quickorder.back": "뒤",
   "store/quickorder.cannotBeDelivered": "배송 불가",
+  "store/quickorder.cannotGetSkuInfo": "SKU 정보를 가져올 수 없습니다",
   "store/quickorder.category.addButton": "장바구니가 비어있습니다",
   "store/quickorder.category.loading": "로딩 중...",
   "store/quickorder.category.noneSelection": "주문 수량을 입력해주세요",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -35,6 +35,7 @@
   "store/quickorder.available": "Disponível",
   "store/quickorder.back": "Voltar",
   "store/quickorder.cannotBeDelivered": "Não pode ser entregue",
+  "store/quickorder.cannotGetSkuInfo": "Não foi possível obter informações do SKU",
   "store/quickorder.category.addButton": "Adicionar itens ao carrinho",
   "store/quickorder.category.loading": "Carregando...",
   "store/quickorder.category.noneSelection": "Informe alguma quantidade nos items desejados",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -35,6 +35,7 @@
   "store/quickorder.available": "Disponibil",
   "store/quickorder.back": "Inapoi",
   "store/quickorder.cannotBeDelivered": "Nu poate fi livrat",
+  "store/quickorder.cannotGetSkuInfo": "Nu s-au primit informațiile SKU",
   "store/quickorder.category.addButton": "Adauga articole in carucior",
   "store/quickorder.category.loading": "Se incarca...",
   "store/quickorder.category.noneSelection": "Introduceti cantitati",

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -57,6 +57,14 @@ export class Search extends JanusClient {
     const resultStr: any = {}
 
     if (res.status === 200) {
+      const orderForm = await this.getOrderForm(orderFormId)
+      const { salesChannel } = orderForm
+
+      // filter out sellers that aren't available in current sales channel
+      this.sellersList = this.sellersList?.filter(seller => {
+        return seller.availableSalesChannels.includes(Number(salesChannel))
+      })
+
       const refs = Object.getOwnPropertyNames(res.data)
 
       refs.forEach(id => {
@@ -76,8 +84,6 @@ export class Search extends JanusClient {
         result = await Promise.all(promises)
       }
 
-      const orderForm = await this.getOrderForm(orderFormId)
-
       // update refIdSellerMap to include list of sellers by SKU
       result.forEach((item: any) => {
         refIdSellerMap[item.refid] = item.sellers
@@ -90,6 +96,8 @@ export class Search extends JanusClient {
         orderForm,
         refIdSellerMap
       )
+
+      if (!items.length) return items
 
       const resItems = items.reduce((acc: any, item: any) => {
         const sellerInfo = {
@@ -207,7 +215,12 @@ export class Search extends JanusClient {
           sku: skuId,
           refid,
           sellers: res.data.SkuSellers.filter((item: any) => {
-            return item.IsActive === true
+            // check if seller is available in current sales channel
+            const inSellersList = this.sellersList?.find(seller => {
+              return seller.id === item.SellerId
+            })
+
+            return item.IsActive === true && inSellersList
           }).map(({ SellerId }: any) => {
             return {
               id: SellerId,
@@ -235,10 +248,17 @@ export class Search extends JanusClient {
         .filter((item: any) => {
           return item.isActive === true
         })
-        .map(({ id, name }: any) => {
+        .map(({ id, name, availableSalesChannels }: any) => {
+          const availableSalesChannelsIds = availableSalesChannels.map(
+            (sc: { id: number }) => {
+              return sc.id
+            }
+          )
+
           return {
             id,
             name,
+            availableSalesChannels: availableSalesChannelsIds,
           }
         })
     }

--- a/node/tests/setupTests.ts
+++ b/node/tests/setupTests.ts
@@ -169,6 +169,14 @@ jest.mock('@vtex/api', () => {
         FulfillmentSellerId: '',
         SellerType: 1,
         IsBetterScope: false,
+        availableSalesChannels: [
+          {
+            id: 2,
+          },
+          {
+            id: 4,
+          },
+        ],
       },
     ],
   })

--- a/react/TextAreaBlock.tsx
+++ b/react/TextAreaBlock.tsx
@@ -317,6 +317,7 @@ const TextAreaBlock: FunctionComponent<
               hiddenColumns={hiddenColumns ?? []}
               onReviewItems={onReviewItems}
               onRefidLoading={onRefidLoading}
+              backList={backList}
             />
             <div
               className={`mb4 mt4 flex justify-between ${handles.buttonsBlock}`}

--- a/react/UploadBlock.tsx
+++ b/react/UploadBlock.tsx
@@ -446,6 +446,7 @@ const UploadBlock: FunctionComponent<
               hiddenColumns={hiddenColumns ?? []}
               onReviewItems={onReviewItems}
               onRefidLoading={onRefidLoading}
+              backList={backList}
             />
             <div
               className={`mb4 mt4 flex justify-between ${handles.buttonsBlock}`}


### PR DESCRIPTION
#### What does this PR do? \*
When validating SKUs in the Review block and the checkout simulation fails, nothing happens and the user continues to see the spinner icon. 
- Added error handling to display toast message and take users back to TextArea and Upload blocks

One scenario where the checkout simulation fails is when the sales channel used for the simulation isn't available for a seller in the simulation.
- Filtered out sellers unavailable in orderForm's sales channel

#### How to test it? \*
Test in workspace [annaquickorder](https://annaquickorder--sandboxusdev.myvtex.com/quickorder).

In _Copy/Paste Skus_, input "880010a,2" and click Validate. SKU 880010a is available in SandBox Seller but SandBox Seller is not available in sales channel 1 so only seller VTEX-UniteU is shown.
<img width="1395" alt="Screen Shot 2022-07-01 at 11 22 42 AM" src="https://user-images.githubusercontent.com/53097865/176923435-1eed7315-312c-45a9-b12c-ebea4fdcaa9c.png">

Here's a screen recording of the error messaging when the filter is not in place and the checkout simulation fails.
https://user-images.githubusercontent.com/53097865/176923600-7ea36f11-e799-459f-9eb1-4dac5178b54f.mov