### PR TITLE
[QUICKORDER-27] Use sales channel from segment in checkout simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Get sales channel from segment instead of orderForm
+
 ## [3.9.3] - 2022-07-05
 
 ### Fixed

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { UserInputError } from '@vtex/api'
+import atob from 'atob'
 
 import { resolvers as refidsResolvers } from './refids'
 
@@ -15,7 +16,8 @@ export const queries = {
     ctx: Context
   ): Promise<any> => {
     const {
-      clients: { search },
+      clients: { search, segment },
+      vtex: { segmentToken },
     } = ctx
 
     if (!args.refids) {
@@ -26,6 +28,9 @@ export const queries = {
       refids: args.refids,
       orderFormId: args.orderFormId,
       refIdSellerMap: args.refIdSellerMap,
+      salesChannel: segmentToken
+        ? JSON.parse(atob(segmentToken)).channel
+        : (await segment.getSegment()).channel,
     })
 
     return {

--- a/node/tests/resolvers.test.ts
+++ b/node/tests/resolvers.test.ts
@@ -1,7 +1,7 @@
 import vtexContext from './vtexContext'
 
 describe('Graphql resolvers', () => {
-  const { Query, clients } = vtexContext()
+  const { Query, clients, vtex } = vtexContext()
 
   it('[GraphQL] skuFromRefIds', async () => {
     const data = await Query.skuFromRefIds(
@@ -13,6 +13,7 @@ describe('Graphql resolvers', () => {
       },
       {
         clients,
+        vtex,
       }
     )
 

--- a/node/tests/setupTests.ts
+++ b/node/tests/setupTests.ts
@@ -253,6 +253,11 @@ jest.mock('@vtex/api', () => {
     IOClients: jest.fn(() => ({
       getOrSet: jest.fn(),
     })),
+    Segment: jest.fn((): any => ({
+      getSegment: jest.fn(() => ({
+        channel: jest.fn(),
+      })),
+    })),
     LRUCache: jest.fn(),
     RecorderState: jest.fn(),
     UserInputError: jest.fn(),

--- a/node/tests/setupTests.ts
+++ b/node/tests/setupTests.ts
@@ -255,7 +255,7 @@ jest.mock('@vtex/api', () => {
     })),
     Segment: jest.fn((): any => ({
       getSegment: jest.fn(() => ({
-        channel: jest.fn(),
+        channel: '1',
       })),
     })),
     LRUCache: jest.fn(),

--- a/node/tests/vtexContext.ts
+++ b/node/tests/vtexContext.ts
@@ -1,4 +1,5 @@
 import type { IOContext } from '@vtex/api'
+import { Segment } from '@vtex/api'
 
 import Service from '../index'
 import { Search } from '../clients/search'
@@ -13,7 +14,10 @@ const vtexContext = () => {
   const context = {} as IOContext
   const clients = {
     search: new Search(context),
+    segment: new Segment(context),
   }
+
+  const vtex = {} as IOContext
 
   return {
     context,
@@ -21,6 +25,7 @@ const vtexContext = () => {
     Query,
     resolvers,
     Service,
+    vtex,
   }
 }
 


### PR DESCRIPTION
#### What does this PR do? \*
It looks like the default sales channel in the orderForm is "1" and gets updated when user adds items to cart. If sales channel "1" is not valid for the store, the checkout simulation will fail when using it. Instead, use the sales channel from VTEX segment when available.

#### How to test it? \*
Test in workspace [anna](https://anna--b2bbenparsell.myvtex.com/quickorder). The following test fails at step 2 in the [master](https://b2bbenparsell.myvtex.com/quickorder) workspace.

1. Navigate to store and check salesChannel in orderForm (should be "1")
2. In _Copy/Paste Skus_, input `FMHT51306,1` and click Validate
3. Click Add to Cart (should appear if checkout simulation worked)
4. Check salesChannel in orderForm (should be "4")
