### PR TITLE
[QUICKORDER-33] Add partial availability check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Run checkout simulation with item quantity input in `TextArea` and `Upload` blocks
+- Check for SKU match in full `items` list from `productSuggestions` query results
 
 ## [3.11.0] - 2022-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Partial availability error message in `ReviewBlock` when full item quantity entered is not available in selected seller
+
+### Changed
+
+- Run checkout simulation with item quantity input in `TextArea` and `Upload` blocks
+
 ## [3.11.0] - 2022-10-06
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -3,6 +3,7 @@ type Query {
     refids: [String]
     orderFormId: String
     refIdSellerMap: RefIdSellerMap
+    refIdQuantityMap: RefIdQuantityMap
   ): Refids @cacheControl(scope: SEGMENT, maxAge: MEDIUM) @withSegment
   sellers: SellersType
     @cacheControl(scope: SEGMENT, maxAge: MEDIUM)
@@ -10,3 +11,5 @@ type Query {
 }
 
 scalar RefIdSellerMap
+
+scalar RefIdQuantityMap

--- a/graphql/types/Refids.graphql
+++ b/graphql/types/Refids.graphql
@@ -12,4 +12,5 @@ type ItemsSeller {
   name: String
   availability: String
   unitMultiplier: Float
+  availableQuantity: Int
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -58,6 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "المنتج بدون سعر",
   "store/quickorder.withoutStock": "بدون مخزون",
   "store/quickorder.limited": "Restricted Item",
+  "store/quickorder.partiallyAvailable": "Max quantity {quantity}. Only {totalQuantity} total units available",
   "store/toaster.cart.duplicated": "عنصر مكرر",
   "store/toaster.cart.error": "خطأ في إضافة المنتجات إلى عربة التسوق",
   "store/toaster.cart.seeCart": "مشاهدة العربة",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -58,7 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "المنتج بدون سعر",
   "store/quickorder.withoutStock": "بدون مخزون",
   "store/quickorder.limited": "Restricted Item",
-  "store/quickorder.partiallyAvailable": "Max quantity {quantity}. Only {totalQuantity} total units available",
+  "store/quickorder.partiallyAvailable": "الكمية القصوى هي {quantity}. فقط {totalQuantity} وحدات إجمالية متاحة.",
   "store/toaster.cart.duplicated": "عنصر مكرر",
   "store/toaster.cart.error": "خطأ في إضافة المنتجات إلى عربة التسوق",
   "store/toaster.cart.seeCart": "مشاهدة العربة",

--- a/messages/context.json
+++ b/messages/context.json
@@ -58,6 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "store/quickorder.withoutPriceFulfillment",
   "store/quickorder.withoutStock": "store/quickorder.withoutStock",
   "store/quickorder.limited": "store/quickorder.limited",
+  "store/quickorder.partiallyAvailable": "store/quickorder.partiallyAvailable",
   "store/toaster.cart.duplicated": "store/toaster.cart.duplicated",
   "store/toaster.cart.error": "store/toaster.cart.error",
   "store/toaster.cart.seeCart": "store/toaster.cart.seeCart",

--- a/messages/en.json
+++ b/messages/en.json
@@ -58,6 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "Product without price",
   "store/quickorder.withoutStock": "Without stock",
   "store/quickorder.limited": "Restricted Item",
+  "store/quickorder.partiallyAvailable": "Max quantity is {quantity}. Only {totalQuantity} total units available.",
   "store/toaster.cart.duplicated": "Item duplicated",
   "store/toaster.cart.error": "Error adding products to the cart",
   "store/toaster.cart.seeCart": "See cart",

--- a/messages/es.json
+++ b/messages/es.json
@@ -58,6 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "Producto sin precio",
   "store/quickorder.withoutStock": "Sin stock",
   "store/quickorder.limited": "Restricted Item",
+  "store/quickorder.partiallyAvailable": "La cantidad máxima es {quantity}. Solo hay {totalQuantity} unidades disponibles.",
   "store/toaster.cart.duplicated": "Elemento duplicado",
   "store/toaster.cart.error": "Error al agregar productos al carrito",
   "store/toaster.cart.seeCart": "Ver el carrito",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -58,6 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "가격정보가 없습니다",
   "store/quickorder.withoutStock": "재고 부족",
   "store/quickorder.limited": "Restricted Item",
+  "store/quickorder.partiallyAvailable": "Max quantity {quantity}. Only {totalQuantity} total units available",
   "store/toaster.cart.duplicated": "중복된 항목이 있습니다",
   "store/toaster.cart.error": "장바구니에 담기가 실패하였습니다",
   "store/toaster.cart.seeCart": "장바구니",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -58,7 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "가격정보가 없습니다",
   "store/quickorder.withoutStock": "재고 부족",
   "store/quickorder.limited": "Restricted Item",
-  "store/quickorder.partiallyAvailable": "Max quantity {quantity}. Only {totalQuantity} total units available",
+  "store/quickorder.partiallyAvailable": "최대 수량은 {quantity}입니다. {totalQuantity} 총 단위만 사용할 수 있습니다.",
   "store/toaster.cart.duplicated": "중복된 항목이 있습니다",
   "store/toaster.cart.error": "장바구니에 담기가 실패하였습니다",
   "store/toaster.cart.seeCart": "장바구니",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -58,6 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "Produto sem preço",
   "store/quickorder.withoutStock": "Sem estoque",
   "store/quickorder.limited": "Restricted Item",
+  "store/quickorder.partiallyAvailable": "A quantidade máxima é {quantity}. Existem apenas {totalQuantity} unidades disponíveis.",
   "store/toaster.cart.duplicated": "Item duplicado",
   "store/toaster.cart.error": "Erro adicionando produtos ao carrinho",
   "store/toaster.cart.seeCart": "Ver o carrinho",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -58,7 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "Produs fără preț",
   "store/quickorder.withoutStock": "Fără stoc",
   "store/quickorder.limited": "Restricted Item",
-  "store/quickorder.partiallyAvailable": "Max quantity {quantity}. Only {totalQuantity} total units available",
+  "store/quickorder.partiallyAvailable": "Cantitatea maximă este {quantity}. Sunt disponibile doar {totalQuantity} unități în total.",
   "store/toaster.cart.duplicated": "Articol duplicat",
   "store/toaster.cart.error": "Eroare la adaugarea produselor in cos",
   "store/toaster.cart.seeCart": "Vezi cos",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -58,6 +58,7 @@
   "store/quickorder.withoutPriceFulfillment": "Produs fără preț",
   "store/quickorder.withoutStock": "Fără stoc",
   "store/quickorder.limited": "Restricted Item",
+  "store/quickorder.partiallyAvailable": "Max quantity {quantity}. Only {totalQuantity} total units available",
   "store/toaster.cart.duplicated": "Articol duplicat",
   "store/toaster.cart.error": "Eroare la adaugarea produselor in cos",
   "store/toaster.cart.seeCart": "Vezi cos",

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -55,7 +55,7 @@ export class Search extends JanusClient {
         refIdSellerMap[item.refid].forEach(sellerId => {
           simulateItems.push({
             id: item.sku,
-            quantity: 1,
+            quantity: item.quantity,
             seller: sellerId,
           })
         })

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -75,6 +75,7 @@ const checkoutSimulation = async (
         seller: item.seller,
         availability: item.availability ?? '',
         unitMultiplier: item.unitMultiplier ?? 1,
+        quantity: item.quantity,
       }
 
       return {
@@ -119,13 +120,14 @@ const getSkuSellers = async (
 
   result = await Promise.all(
     result.map(async (item: any) => {
-      const { sku, refid } = item
+      const { sku, refid, quantity } = item
 
       if (sku === null) {
         return {
           sku,
           refid,
           sellers: null,
+          quantity,
         }
       }
 
@@ -150,6 +152,7 @@ const getSkuSellers = async (
             sku,
             refid,
             sellers: validSellers,
+            quantity,
           }
         })
         .catch((error: any) => {
@@ -164,6 +167,7 @@ const getSkuSellers = async (
             sku,
             refid,
             sellers: null,
+            quantity,
           }
         })
     })
@@ -187,11 +191,15 @@ const getSkuSellerInfo = (simulationResults: any, result: any) => {
         )
 
         const { availability = '', unitMultiplier = 1 } = currSeller ?? {}
+        const isPartiallyAvailable = currSeller.quantity < item.quantity
 
         return {
           ...seller,
-          availability,
+          availability: isPartiallyAvailable
+            ? 'partiallyAvailable'
+            : availability,
           unitMultiplier,
+          availableQuantity: currSeller.quantity,
         }
       })
 
@@ -208,7 +216,12 @@ const getSkuSellerInfo = (simulationResults: any, result: any) => {
 export const queries = {
   skuFromRefIds: async (
     _: any,
-    args: { refids: string; orderFormId: string; refIdSellerMap: any },
+    args: {
+      refids: string
+      orderFormId: string
+      refIdSellerMap: any
+      refIdQuantityMap: any
+    },
     ctx: Context
   ): Promise<any> => {
     const {
@@ -216,7 +229,7 @@ export const queries = {
       vtex: { segment, logger },
     } = ctx
 
-    const { refids, orderFormId, refIdSellerMap } = args
+    const { refids, orderFormId, refIdSellerMap, refIdQuantityMap } = args
 
     if (!refids) {
       throw new UserInputError('No refids provided')
@@ -252,7 +265,9 @@ export const queries = {
           sku: skuIds[id],
           refid: id,
           sellers: sellersList,
+          quantity: refIdQuantityMap?.[id] ?? 1,
         }
+
         result.push(resultStr[id])
       })
 

--- a/node/resolvers/search/index.ts
+++ b/node/resolvers/search/index.ts
@@ -190,8 +190,12 @@ const getSkuSellerInfo = (simulationResults: any, result: any) => {
           (s: any) => s.seller === seller.id
         )
 
-        const { availability = '', unitMultiplier = 1 } = currSeller ?? {}
-        const isPartiallyAvailable = currSeller.quantity < item.quantity
+        const {
+          availability = '',
+          unitMultiplier = 1,
+          quantity: availableQuantity = undefined,
+        } = currSeller ?? {}
+        const isPartiallyAvailable = availableQuantity < item.quantity
 
         return {
           ...seller,
@@ -199,7 +203,7 @@ const getSkuSellerInfo = (simulationResults: any, result: any) => {
             ? 'partiallyAvailable'
             : availability,
           unitMultiplier,
-          availableQuantity: currSeller.quantity,
+          availableQuantity,
         }
       })
 

--- a/node/tests/resolvers.test.ts
+++ b/node/tests/resolvers.test.ts
@@ -10,6 +10,7 @@ describe('Graphql resolvers', () => {
         refids: true,
         orderFormId: '',
         refIdSellerMap: {},
+        refIdQuantityMap: {},
       },
       {
         clients,

--- a/node/tests/setupTests.ts
+++ b/node/tests/setupTests.ts
@@ -201,6 +201,8 @@ jest.mock('@vtex/api', () => {
       {
         sku: 'SKU-MOCKED-1',
         id: '100',
+        quantity: 12,
+        seller: '1',
       },
     ],
   })

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -179,7 +179,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
         /* order of precedence for errors
          * 1) Item not found
-         * 2) Item Availability
+         * 2) Item availability
          * 3) Item restriction
          */
         const notfound = refIdNotFound.find((curr: any) => {
@@ -230,7 +230,9 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           ? item.seller
           : item.sku && mappedRefId[item.sku]?.sellers?.length
           ? mappedRefId[item.sku]?.sellers.find(
-              (seller: any) => seller.availability === 'available'
+              (seller: any) =>
+                seller.availability === 'available' ||
+                seller.availability === 'partiallyAvailable'
             )?.id ?? ''
           : ''
 
@@ -511,11 +513,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           id: 'store/quickorder.review.label.seller',
         }),
         cellRenderer: ({ rowData }: any) => {
-          // select the first seller if no seller selected
-          if (rowData?.sellers?.length && rowData?.seller === '') {
-            updateLineSeller(rowData.index, rowData.sellers[0].id)
-          }
-
           if (rowData?.sellers?.length > 1) {
             return (
               <div>

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -210,13 +210,17 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           ? null
           : `store/quickorder.limited`
 
+        const partialStockError = selectedSellerHasPartialStock
+          ? 'store/quickorder.partiallyAvailable'
+          : null
+
+        const availabilityError = foundHasStock
+          ? partialStockError
+          : `store/quickorder.withoutStock`
+
         ret = notfound
           ? 'store/quickorder.skuNotFound'
-          : (foundHasStock
-              ? selectedSellerHasPartialStock
-                ? 'store/quickorder.partiallyAvailable'
-                : null
-              : `store/quickorder.withoutStock`) ?? itemRestricted
+          : availabilityError ?? itemRestricted
 
         return ret
       }

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -56,6 +56,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     return Promise.all(
       data.map(async (item: any) => {
         const res: any = await checkRestriction(item.refid)
+
         if (
           res?.data?.productSuggestions?.products[0]?.items[0]?.itemId ===
           item.sku
@@ -87,6 +88,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     'store/quickorder.available': messages.available,
     'store/quickorder.invalidPattern': messages.invalidPattern,
     'store/quickorder.skuNotFound': messages.skuNotFound,
+    'store/quickorder.partiallyAvailable': messages.partiallyAvailable,
     'store/quickorder.withoutStock': messages.withoutStock,
     'store/quickorder.withoutPriceFulfillment':
       messages.withoutPriceFulfillment,
@@ -129,7 +131,9 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     refidData?.skuFromRefIds.items.forEach((item: any) => {
       if (!item.sellers) return
       item.sellers = item.sellers.filter(
-        (seller: any) => seller.availability === 'available'
+        (seller: any) =>
+          seller.availability === 'available' ||
+          seller.availability === 'partiallyAvailable'
       )
     })
 
@@ -165,6 +169,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
             return item != null
           })
         )
+
         restrictedData.forEach((item: any) => {
           mappedRefId[item.refid] = item
         })
@@ -184,7 +189,9 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           found?.sellers?.length &&
           found.sellers.filter(
             (seller: any) =>
-              seller.availability && seller.availability === 'available'
+              seller.availability &&
+              (seller.availability === 'available' ||
+                seller.availability === 'partiallyAvailable')
           ).length
 
         ret = notfound
@@ -194,6 +201,22 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           : `store/quickorder.withoutStock`
 
         return ret
+      }
+
+      const partiallyAvailableErrorMsg = (currSeller: string, item: any) => {
+        const found = refIdFound.find((curr: any) => {
+          return curr.refid === item.sku && curr.sku !== null
+        })
+
+        const hasPartialStock =
+          found?.sellers?.length &&
+          found.sellers.find(
+            (seller: any) =>
+              seller.id === currSeller &&
+              seller.availability === 'partiallyAvailable'
+          )
+
+        return hasPartialStock ? 'store/quickorder.partiallyAvailable' : null
       }
 
       if (refIdNotFound.length || refNotAvailable.length) {
@@ -216,6 +239,13 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
               )?.unitMultiplier ?? '1'
             : '1'
 
+        const sellerAvailableQuantity =
+          item.sku && mappedRefId[item.sku]?.sellers?.length
+            ? mappedRefId[item.sku]?.sellers.find(
+                (seller: any) => seller.id === sellerWithStock
+              )?.availableQuantity
+            : null
+
         return {
           ...item,
           sellers: item.sku ? mappedRefId[item.sku]?.sellers : [],
@@ -225,8 +255,10 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           totalQuantity: sellerUnitMultiplier
             ? sellerUnitMultiplier * item.quantity
             : '',
+          availableQuantity: sellerAvailableQuantity ?? item.quantity,
           error:
             errorMsg(item) ??
+            partiallyAvailableErrorMsg(sellerWithStock, item) ??
             (sellerWithStock ? null : `store/quickorder.limited`),
         }
       })
@@ -262,9 +294,16 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     onRefidLoading(true)
     const refids = _refids.length ? Array.from(new Set(_refids)) : []
 
+    const refIdQuantityMap = reviewed.reduce((prev, item) => {
+      return {
+        ...prev,
+        [item.sku]: item.quantity,
+      }
+    }, {})
+
     const query = {
       query: getRefIdTranslation,
-      variables: { refids, orderFormId, refIdSellerMap },
+      variables: { refids, orderFormId, refIdSellerMap, refIdQuantityMap },
     }
 
     try {
@@ -473,6 +512,11 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           id: 'store/quickorder.review.label.seller',
         }),
         cellRenderer: ({ rowData }: any) => {
+          // select the first seller if no seller selected
+          if (rowData?.sellers?.length && rowData?.seller === '') {
+            updateLineSeller(rowData.index, rowData.sellers[0].id)
+          }
+
           if (rowData?.sellers?.length > 1) {
             return (
               <div>
@@ -506,9 +550,15 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
         width: 75,
         cellRenderer: ({ cellData, rowData }: any) => {
           if (rowData.error) {
-            const text = intl.formatMessage(
-              errorMessage[cellData || 'store/quickorder.valid']
-            )
+            const errMsg = errorMessage[cellData || 'store/quickorder.valid']
+            const text =
+              errMsg === messages.partiallyAvailable
+                ? intl.formatMessage(errMsg, {
+                    quantity: rowData.availableQuantity,
+                    totalQuantity:
+                      rowData.availableQuantity * rowData.unitMultiplier,
+                  })
+                : intl.formatMessage(errMsg)
 
             return (
               <span className="pa3 br2 dib mr5 mv0">

--- a/react/queries/refids.gql
+++ b/react/queries/refids.gql
@@ -2,11 +2,13 @@ query getSkuFromRefIds(
   $refids: [String]
   $orderFormId: String
   $refIdSellerMap: RefIdSellerMap
+  $refIdQuantityMap: RefIdQuantityMap
 ) {
   skuFromRefIds(
     refids: $refids
     orderFormId: $orderFormId
     refIdSellerMap: $refIdSellerMap
+    refIdQuantityMap: $refIdQuantityMap
   ) {
     items {
       sku
@@ -16,6 +18,7 @@ query getSkuFromRefIds(
         name
         availability
         unitMultiplier
+        availableQuantity
       }
     }
   }

--- a/react/queries/refids.gql
+++ b/react/queries/refids.gql
@@ -9,7 +9,7 @@ query getSkuFromRefIds(
     orderFormId: $orderFormId
     refIdSellerMap: $refIdSellerMap
     refIdQuantityMap: $refIdQuantityMap
-  ) {
+  ) @context(provider: "vtex.quickorder") {
     items {
       sku
       refid

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -19,6 +19,9 @@ export const reviewMessages = defineMessages({
   skuNotFound: {
     id: `${storePrefix}skuNotFound`,
   },
+  partiallyAvailable: {
+    id: `${storePrefix}partiallyAvailable`,
+  },
   withoutPriceFulfillment: {
     id: `${storePrefix}withoutPriceFulfillment`,
   },


### PR DESCRIPTION
#### What does this PR do? \*

- Run checkout simulation with item quantity input in `TextArea` and `Upload` blocks
- Add partial availability error message in `ReviewBlock` when full item quantity entered is not available in selected seller
- The `productSuggestions` query can return multiple items for a given product but `setRestriction` only checks if the first item in the list matches the SKU entered. This makes it seem like the SKU is restricted when it isn't. Update to check for SKU match in full `items` list from `productSuggestions` query results.

#### How to test it? \*

_Partial Availability_
Test in workspace [annaquickorder](https://annaquickorder--sandboxusdev.myvtex.com/quickorder) in account sandboxusdev. Try the following inputs:
```
880010a,1000
880020a,1000
880030a,1000
```

The partial availability errors should change according to inventory in seller selected:
<img width="1155" alt="Screen Shot 2022-10-07 at 5 17 44 PM" src="https://user-images.githubusercontent.com/53097865/194653957-8762a1af-c0d2-4b89-baa3-dc2981130462.png">

_productSuggestions query_
Run the following query in sandboxusdev. The VTEX SKU ID for "880020a" is "880020" which is the second item in the list.
```
query{
  productSuggestions(fullText: "880020a", hideUnavailableItems: true){
      products {
        items {
          itemId
        }
      }
    }
}
```

<img width="1233" alt="Screen Shot 2022-10-07 at 5 30 37 PM" src="https://user-images.githubusercontent.com/53097865/194659501-c6fcbc86-4b1c-47e9-85b3-245a67f0df10.png">
