### PR TITLE
[QUICKORDER-41] Fixed XLSX dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Fixed XLSX package version
 ## [3.12.3] - 2022-11-23
 
 ### Added

--- a/react/package.json
+++ b/react/package.json
@@ -13,7 +13,7 @@
     "react-apollo": "^3.1.5",
     "react-dom": "^16.9.2",
     "react-intl": "3.9.1",
-    "xlsx": "^0.15.6"
+    "xlsx": "0.15.6"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5410,7 +5410,7 @@ ws@^7.0.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
 
-xlsx@^0.15.6:
+xlsx@0.15.6:
   version "0.15.6"
   resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.15.6.tgz#461f841d6d9ea1a8375e2cd246bf23aece08a1d5"
   integrity sha512-7vD9eutyLs65iDjNFimVN+gk/oDkfkCgpQUjdE82QgzJCrBHC4bGPH7fzKVyy0UPp3gyFVQTQEFJaWaAvZCShQ==


### PR DESCRIPTION
The download spreadsheet model was not setting the correct name and file extension due to a new minor change.
Fixed by setting the package to a fixed version instead

[https://wender--diageocol.myvtex.com/quickorder](https://wender--diageocol.myvtex.com/quickorder)