### PR TITLE
fix to show product name on autocomplete options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": [
     "javascript",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   },
   "eslint.validate": [
     "javascript",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Adjust autocomplete list to show product name rather then product sku name
+- Adjust autocomplete list to show product name rather than just the product sku name
 
 ## [3.15.2] - 2024-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [3.15.3] - 2024-06-10
 
+### Fixed
+
+- Adjust autocomplete list to show product name rather then product sku name
+
 ## [3.15.2] - 2024-06-10
 
 ## [3.15.1] - 2024-05-27

--- a/manifest.json
+++ b/manifest.json
@@ -90,7 +90,9 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/QuickOrderAutocomplete.tsx
+++ b/react/components/QuickOrderAutocomplete.tsx
@@ -119,7 +119,7 @@ const QuickOrderAutocomplete: FunctionComponent<
         })
         .map((item: any) => {
           return {
-            value: item.productId,
+            value: item.items[0].itemId,
             label: item.productName,
             slug: item.linkText,
             thumb: getImageSrc(item.items[0].images[0].imageUrl),

--- a/react/components/QuickOrderAutocomplete.tsx
+++ b/react/components/QuickOrderAutocomplete.tsx
@@ -49,11 +49,9 @@ const CustomOption = (props: any) => {
     )
   }
 
-  const buttonClasses = `${
-    handles.customOptionButton
-  } bn w-100 tl pointer pa4 f6 ${roundedBottom ? 'br2 br--bottom' : ''} ${
-    highlightOption || selected ? 'bg-muted-5' : 'bg-base'
-  }`
+  const buttonClasses = `${handles.customOptionButton
+    } bn w-100 tl pointer pa4 f6 ${roundedBottom ? 'br2 br--bottom' : ''} ${highlightOption || selected ? 'bg-muted-5' : 'bg-base'
+    }`
 
   const thumb = value.thumb ? value.thumb : ''
 
@@ -116,17 +114,17 @@ const QuickOrderAutocomplete: FunctionComponent<
     value: !term.length
       ? []
       : optionsResult
-          .filter((item: any) => {
-            return !!item.items[0].images[0].imageUrl
-          })
-          .map((item: any) => {
-            return {
-              value: item.items[0].itemId,
-              label: item.items[0].name,
-              slug: item.linkText,
-              thumb: getImageSrc(item.items[0].images[0].imageUrl),
-            }
-          }),
+        .filter((item: any) => {
+          return !!item.items[0].images[0].imageUrl
+        })
+        .map((item: any) => {
+          return {
+            value: item.productName,
+            label: item.productName,
+            slug: item.linkText,
+            thumb: getImageSrc(item.items[0].images[0].imageUrl),
+          }
+        }),
     lastSearched: {
       value: lastSearched,
       label: 'Last searched products',
@@ -156,7 +154,7 @@ const QuickOrderAutocomplete: FunctionComponent<
         setTerm(nterm)
       }
     },
-    onSearch: () => () => {},
+    onSearch: () => () => { },
     onClear: () => setTerm(''),
     placeholder: intl.formatMessage(messages.placeholder),
     value: term,

--- a/react/components/QuickOrderAutocomplete.tsx
+++ b/react/components/QuickOrderAutocomplete.tsx
@@ -119,7 +119,7 @@ const QuickOrderAutocomplete: FunctionComponent<
         })
         .map((item: any) => {
           return {
-            value: item.productName,
+            value: item.productId,
             label: item.productName,
             slug: item.linkText,
             thumb: getImageSrc(item.items[0].images[0].imageUrl),

--- a/react/queries/autocomplete.gql
+++ b/react/queries/autocomplete.gql
@@ -3,6 +3,7 @@ query Autocomplete($inputValue: String!) {
     @context(provider: "vtex.search-graphql") {
       products {
         productName
+        productId
         items {
           itemId
           name

--- a/react/queries/autocomplete.gql
+++ b/react/queries/autocomplete.gql
@@ -2,6 +2,7 @@ query Autocomplete($inputValue: String!) {
   productSuggestions(fullText: $inputValue, hideUnavailableItems: true)
     @context(provider: "vtex.search-graphql") {
       products {
+        productName
         items {
           itemId
           name


### PR DESCRIPTION
#### What does this PR do? \*

This PR modifies the list of autocomplete options to display the product name rather than the product SKU name.

#### How to test it? \*

In 'One by One' mode, type the name of a product, and a list of related products will appear instead of a list of related SKUs.
