### PR TITLE
fix: [quick order] adjust validation of skus and show better status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Fixes validation of SKU codes in the quickorder ReviewBlock component
+- Fixes validation of SKU codes in the quickorder and styles of the ReviewBlock component
 
 ## [3.15.4] - 2024-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixes validation of SKU codes in the quickorder ReviewBlock component
+
 ## [3.15.4] - 2024-06-13
 
 ## [3.15.3] - 2024-06-10

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -508,7 +508,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
             {intl.formatMessage({
               id: 'store/quickorder.review.label.totalQuantity',
             })}
-            aa
           </div>
         ),
         width: 82,

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -7,10 +7,9 @@ import {
   Input,
   ButtonWithIcon,
   IconDelete,
-  IconInfo,
-  Tooltip,
   Dropdown,
   ToastContext,
+  Tag,
 } from 'vtex.styleguide'
 import type { WrappedComponentProps } from 'react-intl'
 import { injectIntl } from 'react-intl'
@@ -32,8 +31,8 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
   hiddenColumns,
   reviewedItems,
   onRefidLoading,
-  backList,
   intl,
+  backList,
 }: any) => {
   const client = useApolloClient()
   const { showToast } = useContext(ToastContext)
@@ -128,11 +127,11 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
     // drops sellers without stock from refidData
     refidData?.skuFromRefIds.items.forEach((item: any) => {
-      if (!item.sellers) return
+      if (!item?.sellers) return
       item.sellers = item.sellers.filter(
         (seller: any) =>
-          seller.availability === 'available' ||
-          seller.availability === 'partiallyAvailable'
+          seller?.availability === 'available' ||
+          seller?.availability === 'partiallyAvailable'
       )
     })
 
@@ -192,19 +191,20 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
         let selectedSellerHasPartialStock
         const foundHasStock =
-          found?.sellers?.length &&
-          found.sellers.filter((seller: any) => {
-            if (seller.id === sellerWithStock) {
-              selectedSellerHasPartialStock =
-                seller.availability === 'partiallyAvailable'
-            }
+          (found?.sellers?.length &&
+            found.sellers.filter((seller: any) => {
+              if (seller?.id === sellerWithStock) {
+                selectedSellerHasPartialStock =
+                  seller?.availability === 'partiallyAvailable'
+              }
 
-            return (
-              seller.availability &&
-              (seller.availability === 'available' ||
-                seller.availability === 'partiallyAvailable')
-            )
-          }).length
+              return (
+                seller?.availability &&
+                (seller?.availability === 'available' ||
+                  seller?.availability === 'partiallyAvailable')
+              )
+            })?.length) ||
+          0
 
         const itemRestricted = sellerWithStock
           ? null
@@ -281,6 +281,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
       })
 
       onReviewItems(updated)
+
       if (JSON.stringify(reviewItems) !== JSON.stringify(updated)) {
         setReviewState({
           ...state,
@@ -546,7 +547,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
         title: intl.formatMessage({
           id: 'store/quickorder.review.label.status',
         }),
-        width: 75,
+
         cellRenderer: ({ cellData, rowData }: any) => {
           if (rowData.error) {
             const errMsg = errorMessage[cellData || 'store/quickorder.valid']
@@ -560,12 +561,10 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
                 : intl.formatMessage(errMsg)
 
             return (
-              <span className="pa3 br2 dib mr5 mv0">
-                <Tooltip label={text}>
-                  <span className="c-danger pointer">
-                    <IconInfo />
-                  </span>
-                </Tooltip>
+              <span>
+                <Tag type="error" variation="low">
+                  {text}
+                </Tag>
               </span>
             )
           }

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -476,7 +476,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
       tableSchema.properties.sku = {
         type: 'string',
         title: intl.formatMessage({ id: 'store/quickorder.review.label.sku' }),
-        width: 125,
+        width: 112,
       }
     }
 
@@ -486,7 +486,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
         title: intl.formatMessage({
           id: 'store/quickorder.review.label.quantity',
         }),
-        width: 75,
+        width: 72,
       }
     }
 
@@ -501,12 +501,20 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     }
 
     if (columnsToBeHidden.indexOf('totalQuantity') === -1) {
+      const totalQuantity = intl.formatMessage({
+        id: 'store/quickorder.review.label.totalQuantity',
+      }) as string
+
+      const [quantity, total] = totalQuantity.split(' ')
+
       tableSchema.properties.totalQuantity = {
         type: 'float',
-        title: intl.formatMessage({
-          id: 'store/quickorder.review.label.totalQuantity',
-        }),
-        width: 100,
+        title: (
+          <>
+            {quantity} <span style={{ display: 'block' }}>{total}</span>
+          </>
+        ),
+        width: 82,
       }
     }
 
@@ -547,7 +555,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
         title: intl.formatMessage({
           id: 'store/quickorder.review.label.status',
         }),
-
         cellRenderer: ({ cellData, rowData }: any) => {
           if (rowData.error) {
             const errMsg = errorMessage[cellData || 'store/quickorder.valid']
@@ -562,7 +569,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
             return (
               <span>
-                <Tag type="error" variation="low">
+                <Tag type="error" variation="low" size="small">
                   {text}
                 </Tag>
               </span>
@@ -578,7 +585,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
       tableSchema.properties.delete = {
         type: 'object',
         title: ' ',
-        width: 75,
+        width: 58,
         // eslint-disable-next-line react/display-name
         cellRenderer: ({ rowData }: any) => {
           return (

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -501,18 +501,15 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     }
 
     if (columnsToBeHidden.indexOf('totalQuantity') === -1) {
-      const totalQuantity = intl.formatMessage({
-        id: 'store/quickorder.review.label.totalQuantity',
-      }) as string
-
-      const [quantity, total] = totalQuantity.split(' ')
-
       tableSchema.properties.totalQuantity = {
         type: 'float',
         title: (
-          <>
-            {quantity} <span style={{ display: 'block' }}>{total}</span>
-          </>
+          <div style={{ whiteSpace: 'break-spaces' }}>
+            {intl.formatMessage({
+              id: 'store/quickorder.review.label.totalQuantity',
+            })}
+            aa
+          </div>
         ),
         width: 82,
       }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -23,4 +23,5 @@ declare module 'vtex.styleguide' {
   export const IconClear
   export const Tag
   export const Collapsible
+  export const Alert
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -23,5 +23,4 @@ declare module 'vtex.styleguide' {
   export const IconClear
   export const Tag
   export const Collapsible
-  export const Alert
 }


### PR DESCRIPTION
#### What does this PR do? \*
This PR includes the SKU validate fix, now it's possible to show the feedback reason error about the SKUs codes input at autocomplete and adjust style of the ReviewBlock component

#### How to test it? \*
navigate to the page [workspace]/quickorder and enter with SKU code at autocomplete

#### Describe alternatives you've considered, if any. \*
[Screen Recording 2024-08-14 at 10.15.56.zip](https://github.com/user-attachments/files/16613783/Screen.Recording.2024-08-14.at.10.15.56.zip)
<img width="1092" alt="Screenshot 2024-08-19 at 11 20 29" src="https://github.com/user-attachments/assets/1dfff950-05b1-42ff-a052-1fb341c4d758">

#### Related to / Depends on \*

<!--- Optional -->
