### PR TITLE
Fix/adjust counting problem quickorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Fixed quickorder listing counter
 
 ## [3.16.1] - 2024-11-12
 ### Fixed

--- a/react/UploadBlock.tsx
+++ b/react/UploadBlock.tsx
@@ -213,6 +213,7 @@ const UploadBlock: FunctionComponent<
 
   const handleFile = (files: any) => {
     doFile(files)
+    onRefidLoading(false)
   }
 
   const handleReset = () => {
@@ -435,6 +436,7 @@ const UploadBlock: FunctionComponent<
               reviewedItems={reviewItems}
               hiddenColumns={hiddenColumns ?? []}
               onReviewItems={onReviewItems}
+              refidLoading={refidLoading}
               onRefidLoading={onRefidLoading}
               backList={backList}
             />

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -433,6 +433,8 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
   const createSchema = (columnsToBeHidden: string[]) => {
     if (columnsToBeHidden.indexOf('line') === -1) {
+      let count = 0
+
       tableSchema.properties.line = {
         type: 'object',
         title: intl.formatMessage({
@@ -440,8 +442,10 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
         }),
         width: 50,
         // eslint-disable-next-line react/display-name
-        cellRenderer: ({ rowData }: any) => {
-          return <div>{parseInt(rowData.line, 10) + 1}</div>
+        cellRenderer: () => {
+          count++
+
+          return <div>{refidLoading ? '-' : count}</div>
         },
       }
     }


### PR DESCRIPTION
#### What does this PR do? \*
Adjusts the quickorder table listing, regardless of whether the sku is repeated

#### How to test it? \*
1. Go to [https://soares--b2bstore005.myvtex.com/quickorder](https://soares--b2bstore005.myvtex.com/quickorder)
2. Enter with skus at "Copy/Paste Skus"


https://github.com/user-attachments/assets/9b4bae7d-8304-431b-b51a-47512ea05ee9



#### Describe alternatives you've considered, if any. \*

<!--- Optional -->

#### Related to / Depends on \*

<!--- Optional -->
