### PR TITLE
[FSEUS-731] Fixing autocomplete for French

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Autocomplete not working with French language
 
 ## [3.16.0] - 2024-11-07
 ### Added
 
-- Changed the checkoutUrl prop to admin app settings 
+- Changed the checkoutUrl prop to admin app settings
 
 ## [3.15.9] - 2024-10-02
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "quickorder",
-  "version": "3.16.0",
+  "version": "3.16.1-beta.0",
   "title": "Quickorder",
   "description": "Allow users to add multiple products to the cart at once",
   "defaultLocale": "en-US",
@@ -102,9 +102,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@gocommerce/utils": "^0.7.3",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "atob": "^2.1.2",
     "axios": "^0.19.0",
     "camelcase": "^5.0.0",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1863,10 +1863,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/AutocompleteBlock.tsx
+++ b/react/AutocompleteBlock.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react/prop-types */
 import type { FunctionComponent } from 'react'
@@ -179,7 +180,7 @@ const AutocompleteBlock: FunctionComponent<any & WrappedComponentProps> = ({
     if (!!product && product.length) {
       const query = {
         query: productQuery,
-        variables: { slug: product[0].slug },
+        variables: { skuId: product[0].value },
       }
 
       const { data } = await client.query(query)

--- a/react/queries/product.gql
+++ b/react/queries/product.gql
@@ -1,5 +1,6 @@
-query Product($slug: String) {
-  product(slug: $slug) @context(provider: "vtex.search-graphql") {
+query Product($skuId: ID!) {
+  product(identifier: { field: sku, value: $skuId })
+    @context(provider: "vtex.search-graphql") {
     productName
     items {
       itemId


### PR DESCRIPTION
#### What does this PR do? \*
It fixes the error when selecting the product in the autocomplete module when the store language is French.
The problem is that the query to get the SKU detail uses product slug that is not translated for the intelligent search, this fix changes it to look for the ID which is immutable and will work for any other language.

#### How to test it? \*
Access https://dev--ronadev.myvtex.com/commande-rapide?__bindingAddress=ronadev.myvtex.com/fr&sc=1
Try to add a product search `Jardinière haute en plastique noir DCN Harmony 12 x 18 po`
![image](https://github.com/user-attachments/assets/ded907de-5d68-47e6-9d6c-2534bfdeede4)


Not able to add, gets the graphql error. Only works with english version
![image](https://github.com/user-attachments/assets/a1562804-8f36-456e-88fd-49a1805f2e8b)

The change consists on changing the search input to look for the SKU ID instead of the slug
![image](https://github.com/user-attachments/assets/149c67ec-eee3-4b0d-8197-114ce902d5f6)

 
