### PR TITLE
Fixing scenario where false unavailable items are show on ReviewBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `ReviewBlock` seller resolution to use sellers returned by `skuFromRefIds` instead of the autocomplete restriction map, preventing false "Restricted Item" errors and missing seller dropdowns when multiple sellers are available for the active sales channel (including marketplace sellers with non-numeric IDs)
+
 ## [3.16.7] - 2026-03-06
 
 ### Changed

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -6759,9 +6759,9 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
-  version "2.2.0"
-  resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
+stats-lite@vtex/node-stats-lite#dist:
+  version "2.2.1"
+  resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/a0b5ee91861f31b6ec845146b4906faf5172c430"
   dependencies:
     isnumber "~1.0.0"
 

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -21,7 +21,6 @@ import { reviewMessages as messages } from '../utils/messages'
 import { ParseText, GetText } from '../utils'
 import getRefIdTranslation from '../queries/refids.gql'
 import OrderFormQuery from '../queries/orderForm.gql'
-import autocomplete from '../queries/autocomplete.gql'
 
 const remove = <IconDelete />
 
@@ -45,27 +44,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     ssr: false,
     skip: !!orderFormId,
   })
-
-  const checkRestriction = async (sku: any) => {
-    return client.query({
-      query: autocomplete,
-      variables: { inputValue: sku },
-    })
-  }
-
-  const setRestriction = async (data: any) => {
-    const promises = data.map((item: any) =>
-      checkRestriction(item.refid).then((res: any) => {
-        const foundSku = res?.data?.productSuggestions?.products[0]?.items.find(
-          (suggestedItem) => suggestedItem.itemId === item.sku
-        )
-
-        return foundSku ? item : null
-      })
-    )
-
-    return Promise.all(promises)
-  }
 
   const [state, setReviewState] = useState<any>({
     reviewItems:
@@ -161,22 +139,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
             })
           : []
 
-      const mappedRefId = {}
-
-      if (refidData?.skuFromRefIds?.items) {
-        const restrictedData = await setRestriction(
-          refidData.skuFromRefIds.items
-        ).then((data) =>
-          data.filter((item: any) => {
-            return item != null
-          })
-        )
-
-        restrictedData.forEach((item: any) => {
-          mappedRefId[item.refid] = item
-        })
-      }
-
       const errorMsg = (item: any, sellerWithStock: string) => {
         const { sku } = item
 
@@ -222,6 +184,22 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           ? 'store/quickorder.limited'
           : null
 
+        if (itemRestricted && foundHasStock) {
+          console.log(
+            '[quickorder:ReviewBlock] "Restricted Item" shown despite API reporting stock',
+            {
+              refId: sku,
+              sellerWithStock,
+              foundHasStock,
+              foundSellers: found?.sellers?.map((s: any) => ({
+                id: s.id,
+                name: s.name,
+                availability: s.availability,
+              })),
+            }
+          )
+        }
+
         // Final return
         return notfound
           ? 'store/quickorder.skuNotFound'
@@ -232,36 +210,126 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
         error = true
       }
 
+      const refIdApiMap: Record<string, any> = {}
+
+      refIdFound.forEach((apiItem: any) => {
+        refIdApiMap[apiItem.refid] = apiItem
+      })
+
+      const findFirstSellerWithStock = (sellers: any[] = []) =>
+        sellers.find(
+          (seller: any) =>
+            seller.availability === 'available' ||
+            seller.availability === 'partiallyAvailable'
+        )
+
       const items = reviewed.map((item: any) => {
+        const refIdDataItem = refIdApiMap[item.sku]
+        const rowSellers = refIdDataItem?.sellers ?? []
+
         const sellerWithStock = item.seller
           ? item.seller
-          : item.sku && mappedRefId[item.sku]?.sellers?.length
-          ? mappedRefId[item.sku]?.sellers.find(
-              (seller: any) =>
-                seller.availability === 'available' ||
-                seller.availability === 'partiallyAvailable'
-            )?.id ?? ''
-          : ''
+          : findFirstSellerWithStock(rowSellers)?.id ?? ''
 
-        const sellerUnitMultiplier =
-          item.sku && mappedRefId[item.sku]?.sellers?.length
-            ? mappedRefId[item.sku]?.sellers.find(
-                (seller: any) => seller.id === sellerWithStock
-              )?.unitMultiplier ?? '1'
-            : '1'
+        const selectedSeller = rowSellers.find(
+          (seller: any) => seller.id === sellerWithStock
+        )
 
-        const sellerAvailableQuantity =
-          item.sku && mappedRefId[item.sku]?.sellers?.length
-            ? mappedRefId[item.sku]?.sellers.find(
-                (seller: any) => seller.id === sellerWithStock
-              )?.availableQuantity
-            : null
+        const availableSellersFromApi =
+          rowSellers.filter(
+            (seller: any) =>
+              seller.availability === 'available' ||
+              seller.availability === 'partiallyAvailable'
+          )
+
+        if (
+          !sellerWithStock &&
+          availableSellersFromApi.length > 0
+        ) {
+          console.log(
+            '[quickorder:ReviewBlock] Restricted Item scenario — stock exists but no seller resolved',
+            {
+              refId: item.sku,
+              vtexSku: refIdDataItem?.sku,
+              itemSeller: item.seller,
+              resolvedSellerWithStock: sellerWithStock,
+              apiSellers: rowSellers,
+              availableSellersFromApi: availableSellersFromApi.map(
+                (s: any) => ({ id: s.id, name: s.name, availability: s.availability })
+              ),
+            }
+          )
+        }
+
+        if (
+          sellerWithStock &&
+          selectedSeller &&
+          selectedSeller.availability === 'withoutStock' &&
+          availableSellersFromApi.some((s: any) => s.id !== sellerWithStock)
+        ) {
+          console.log(
+            '[quickorder:ReviewBlock] Selected seller has no stock but other sellers are available',
+            {
+              refId: item.sku,
+              vtexSku: refIdDataItem?.sku,
+              selectedSellerId: sellerWithStock,
+              selectedSellerAvailability: selectedSeller.availability,
+              otherAvailableSellers: availableSellersFromApi
+                .filter((s: any) => s.id !== sellerWithStock)
+                .map((s: any) => ({
+                  id: s.id,
+                  name: s.name,
+                  availability: s.availability,
+                })),
+            }
+          )
+        }
+
+        const sellerUnitMultiplier = selectedSeller?.unitMultiplier ?? '1'
+        const sellerAvailableQuantity = selectedSeller?.availableQuantity ?? null
+
+        const dropdownOptions = rowSellers.filter(
+          (seller: any) => seller?.availability !== 'withoutStock'
+        )
+        const hasStockInRowSellers = rowSellers.find(
+          (seller: any) => seller?.availability !== 'withoutStock'
+        )
+        const willShowDropdown = rowSellers.length > 1
+        const sellerDisplayMode = willShowDropdown
+          ? 'dropdown'
+          : rowSellers.length && hasStockInRowSellers
+          ? 'singleName'
+          : 'empty'
+
+        console.log(
+          '[quickorder:ReviewBlock] Seller column display resolution',
+          {
+            refId: item.sku,
+            vtexSku: refIdDataItem?.sku,
+            displayMode: sellerDisplayMode,
+            willShowDropdown,
+            dropdownCondition: 'rowData.sellers.length > 1',
+            rowSellersCount: rowSellers.length,
+            rowSellers: rowSellers.map((s: any) => ({
+              id: s.id,
+              name: s.name,
+              availability: s.availability,
+              availableQuantity: s.availableQuantity,
+            })),
+            dropdownOptions: dropdownOptions.map((s: any) => ({
+              id: s.id,
+              name: s.name,
+              availability: s.availability,
+            })),
+            selectedSeller: sellerWithStock,
+          }
+        )
 
         return {
           ...item,
-          sellers: item.sku ? mappedRefId[item.sku]?.sellers : [],
+          sellers: rowSellers,
           seller: sellerWithStock,
-          vtexSku: item.sku ? mappedRefId[item.sku]?.sku : '1',
+          vtexSku: refIdDataItem?.sku ?? item.vtexSku,
           unitMultiplier: sellerUnitMultiplier,
           totalQuantity: sellerUnitMultiplier
             ? sellerUnitMultiplier * item.quantity
@@ -318,6 +386,20 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     try {
       const { data } = await client.query(query)
 
+      console.log('[quickorder:ReviewBlock] skuFromRefIds response', {
+        refIdSellerMap,
+        items: data?.skuFromRefIds?.items?.map((item: any) => ({
+          refid: item.refid,
+          sku: item.sku,
+          sellers: item.sellers?.map((s: any) => ({
+            id: s.id,
+            name: s.name,
+            availability: s.availability,
+            availableQuantity: s.availableQuantity,
+          })),
+        })),
+      })
+
       await validateRefids(data, reviewed)
       onRefidLoading(false)
     } catch (err) {
@@ -339,6 +421,13 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
         return item.sku
       })
+
+    console.log('[quickorder:ReviewBlock] convertRefIds — initial refIdSellerMap', {
+      refIdSellerMap,
+      orderFormId,
+      note:
+        'Seller "1" is hardcoded; backend may return marketplace sellers (e.g. "cromosolsc1") for the active sales channel',
+    })
 
     getRefIds(refids, items, refIdSellerMap)
   }
@@ -525,18 +614,51 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           id: 'store/quickorder.review.label.seller',
         }),
         cellRenderer: ({ rowData }: any) => {
-          if (rowData?.sellers?.length > 1) {
+          const sellers = rowData?.sellers ?? []
+          const dropdownOptions = sellers.filter(
+            (seller: { availability?: string }) =>
+              seller?.availability !== 'withoutStock'
+          )
+          const willShowDropdown = sellers.length > 1
+          const hasStock = sellers.find(
+            (seller?: { availability: string; [key: string]: unknown }) =>
+              seller?.availability !== 'withoutStock'
+          )
+          const displayMode = willShowDropdown
+            ? 'dropdown'
+            : sellers.length && hasStock
+            ? 'singleName'
+            : 'empty'
+
+          if (!refidLoading) {
+            console.log(
+              '[quickorder:ReviewBlock] Seller cell render',
+              {
+                refId: rowData.sku,
+                lineIndex: rowData.index,
+                displayMode,
+                willShowDropdown,
+                sellersCount: sellers.length,
+                availableSellers: dropdownOptions.map((s: any) => ({
+                  id: s.id,
+                  name: s.name,
+                  availability: s.availability,
+                })),
+                selectedSeller: rowData.seller,
+              }
+            )
+          }
+
+          if (willShowDropdown) {
             return (
               <div>
                 <Dropdown
-                  options={rowData.sellers
-                    .filter((seller) => seller?.availability !== 'withoutStock')
-                    .map((item: any) => {
-                      return {
-                        label: item.name,
-                        value: item.id,
-                      }
-                    })}
+                  options={dropdownOptions.map((item: any) => {
+                    return {
+                      label: item.name,
+                      value: item.id,
+                    }
+                  })}
                   value={rowData.seller}
                   onChange={(_: any, v: any) => {
                     updateLineSeller(rowData.index, v)
@@ -546,14 +668,7 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
             )
           }
 
-          const hasStock = rowData?.sellers?.find(
-            (seller?: { availability: string; [key: string]: unknown }) =>
-              seller?.availability !== 'withoutStock'
-          )
-
-          return rowData?.sellers?.length && hasStock
-            ? rowData.sellers[0].name
-            : ''
+          return sellers.length && hasStock ? sellers[0].name : ''
         },
       }
     }

--- a/react/components/ReviewBlock.tsx
+++ b/react/components/ReviewBlock.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable vtex/prefer-early-return */
 import type { FunctionComponent } from 'react'
@@ -184,26 +183,10 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
           ? 'store/quickorder.limited'
           : null
 
-        if (itemRestricted && foundHasStock) {
-          console.log(
-            '[quickorder:ReviewBlock] "Restricted Item" shown despite API reporting stock',
-            {
-              refId: sku,
-              sellerWithStock,
-              foundHasStock,
-              foundSellers: found?.sellers?.map((s: any) => ({
-                id: s.id,
-                name: s.name,
-                availability: s.availability,
-              })),
-            }
-          )
-        }
-
         // Final return
         return notfound
           ? 'store/quickorder.skuNotFound'
-          : availabilityError ?? itemRestricted
+          : (availabilityError ?? itemRestricted)
       }
 
       if (refIdNotFound.length || refNotAvailable.length) {
@@ -229,101 +212,15 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
         const sellerWithStock = item.seller
           ? item.seller
-          : findFirstSellerWithStock(rowSellers)?.id ?? ''
+          : (findFirstSellerWithStock(rowSellers)?.id ?? '')
 
         const selectedSeller = rowSellers.find(
           (seller: any) => seller.id === sellerWithStock
         )
 
-        const availableSellersFromApi =
-          rowSellers.filter(
-            (seller: any) =>
-              seller.availability === 'available' ||
-              seller.availability === 'partiallyAvailable'
-          )
-
-        if (
-          !sellerWithStock &&
-          availableSellersFromApi.length > 0
-        ) {
-          console.log(
-            '[quickorder:ReviewBlock] Restricted Item scenario — stock exists but no seller resolved',
-            {
-              refId: item.sku,
-              vtexSku: refIdDataItem?.sku,
-              itemSeller: item.seller,
-              resolvedSellerWithStock: sellerWithStock,
-              apiSellers: rowSellers,
-              availableSellersFromApi: availableSellersFromApi.map(
-                (s: any) => ({ id: s.id, name: s.name, availability: s.availability })
-              ),
-            }
-          )
-        }
-
-        if (
-          sellerWithStock &&
-          selectedSeller &&
-          selectedSeller.availability === 'withoutStock' &&
-          availableSellersFromApi.some((s: any) => s.id !== sellerWithStock)
-        ) {
-          console.log(
-            '[quickorder:ReviewBlock] Selected seller has no stock but other sellers are available',
-            {
-              refId: item.sku,
-              vtexSku: refIdDataItem?.sku,
-              selectedSellerId: sellerWithStock,
-              selectedSellerAvailability: selectedSeller.availability,
-              otherAvailableSellers: availableSellersFromApi
-                .filter((s: any) => s.id !== sellerWithStock)
-                .map((s: any) => ({
-                  id: s.id,
-                  name: s.name,
-                  availability: s.availability,
-                })),
-            }
-          )
-        }
-
         const sellerUnitMultiplier = selectedSeller?.unitMultiplier ?? '1'
-        const sellerAvailableQuantity = selectedSeller?.availableQuantity ?? null
-
-        const dropdownOptions = rowSellers.filter(
-          (seller: any) => seller?.availability !== 'withoutStock'
-        )
-        const hasStockInRowSellers = rowSellers.find(
-          (seller: any) => seller?.availability !== 'withoutStock'
-        )
-        const willShowDropdown = rowSellers.length > 1
-        const sellerDisplayMode = willShowDropdown
-          ? 'dropdown'
-          : rowSellers.length && hasStockInRowSellers
-          ? 'singleName'
-          : 'empty'
-
-        console.log(
-          '[quickorder:ReviewBlock] Seller column display resolution',
-          {
-            refId: item.sku,
-            vtexSku: refIdDataItem?.sku,
-            displayMode: sellerDisplayMode,
-            willShowDropdown,
-            dropdownCondition: 'rowData.sellers.length > 1',
-            rowSellersCount: rowSellers.length,
-            rowSellers: rowSellers.map((s: any) => ({
-              id: s.id,
-              name: s.name,
-              availability: s.availability,
-              availableQuantity: s.availableQuantity,
-            })),
-            dropdownOptions: dropdownOptions.map((s: any) => ({
-              id: s.id,
-              name: s.name,
-              availability: s.availability,
-            })),
-            selectedSeller: sellerWithStock,
-          }
-        )
+        const sellerAvailableQuantity =
+          selectedSeller?.availableQuantity ?? null
 
         return {
           ...item,
@@ -386,20 +283,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
     try {
       const { data } = await client.query(query)
 
-      console.log('[quickorder:ReviewBlock] skuFromRefIds response', {
-        refIdSellerMap,
-        items: data?.skuFromRefIds?.items?.map((item: any) => ({
-          refid: item.refid,
-          sku: item.sku,
-          sellers: item.sellers?.map((s: any) => ({
-            id: s.id,
-            name: s.name,
-            availability: s.availability,
-            availableQuantity: s.availableQuantity,
-          })),
-        })),
-      })
-
       await validateRefids(data, reviewed)
       onRefidLoading(false)
     } catch (err) {
@@ -421,13 +304,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
 
         return item.sku
       })
-
-    console.log('[quickorder:ReviewBlock] convertRefIds — initial refIdSellerMap', {
-      refIdSellerMap,
-      orderFormId,
-      note:
-        'Seller "1" is hardcoded; backend may return marketplace sellers (e.g. "cromosolsc1") for the active sales channel',
-    })
 
     getRefIds(refids, items, refIdSellerMap)
   }
@@ -624,30 +500,6 @@ const ReviewBlock: FunctionComponent<WrappedComponentProps & any> = ({
             (seller?: { availability: string; [key: string]: unknown }) =>
               seller?.availability !== 'withoutStock'
           )
-          const displayMode = willShowDropdown
-            ? 'dropdown'
-            : sellers.length && hasStock
-            ? 'singleName'
-            : 'empty'
-
-          if (!refidLoading) {
-            console.log(
-              '[quickorder:ReviewBlock] Seller cell render',
-              {
-                refId: rowData.sku,
-                lineIndex: rowData.index,
-                displayMode,
-                willShowDropdown,
-                sellersCount: sellers.length,
-                availableSellers: dropdownOptions.map((s: any) => ({
-                  id: s.id,
-                  name: s.name,
-                  availability: s.availability,
-                })),
-                selectedSeller: rowData.seller,
-              }
-            )
-          }
 
           if (willShowDropdown) {
             return (


### PR DESCRIPTION
#### What does this PR do?

Fixes seller resolution in `ReviewBlock` during refId validation (Copy/Paste and Upload flows).

**Problem:** After `skuFromRefIds`, seller data was taken from `mappedRefId`, which was only filled for items found in the autocomplete restriction check. When an item was missing from that map, the UI got:
- empty `rowData.sellers` → no seller dropdown even when the API returned multiple sellers
- empty `sellerWithStock` → false **"Restricted Item"** even when stock existed on another seller

This showed up in stores with multiple sellers per SKU (e.g. default seller `"1"` without stock + marketplace seller `"cromosolsc1"` with stock on sales channel `4`).

**Solution:**
- Build seller data from the `skuFromRefIds` API response (`refIdApiMap`)
- Auto-select the first seller with `available` or `partiallyAvailable` stock
- Use that seller for `vtexSku`, `unitMultiplier`, and `availableQuantity`
- Remove unused `setRestriction` / `checkRestriction` autocomplete logic that fed the broken `mappedRefId` flow

---

#### How to test it?

[Workspace](https://pedidos.cromosol.com/quickorder?workspace=wender)

**Example:** RefId `1006` → SKU `12250`, sellers `"1"` (`withoutStock`) and `"cromosolsc1"` (`available`).

1. Open Quick Order and paste/upload a line with the refId (e.g. `1006,1`).
2. Wait for validation to finish.
3. **Expected:**
   - Status is **Valid** (not "Restricted Item")
   - Seller column shows a **dropdown** with both sellers (seller without stock excluded from options)
   - Default selection is the seller with stock (`cromosolsc1` / `CROMOSOL`)
4. Change seller in the dropdown and confirm status/quantity update for the selected seller.
5. Regression: single-seller SKU still shows the seller name (no dropdown) and validates correctly.
6. Regression: refId not found → **SKU not found**; SKU with no available sellers → **Without stock**.

**Optional:** In devtools, confirm `skuFromRefIds` returns multiple sellers and the review row has `sellers.length > 1` and a resolved `seller`.

#### Screenshots
Before:
<img width="3783" height="1526" alt="image" src="https://github.com/user-attachments/assets/8bff530e-3b1d-4890-b4ce-e67d00dfe7cd" />

After:
<img width="987" height="288" alt="image" src="https://github.com/user-attachments/assets/e5dc289f-4a8c-4ab2-ac4e-dd1236382db4" />

<img width="1491" height="185" alt="image" src="https://github.com/user-attachments/assets/0925ed07-8a2f-4728-baea-0da6a7373a74" />
